### PR TITLE
PHP 7 warnings cleanup

### DIFF
--- a/Accounting.php
+++ b/Accounting.php
@@ -88,7 +88,7 @@ function getBankAccountObj($dataService) {
     if ($error) {
         logError($error);
     } else {
-        if (sizeof($accountArray) > 0) {
+        if (is_array($accountArray) && sizeof($accountArray) > 0) {
             return current($accountArray);
         }
     }
@@ -121,7 +121,7 @@ function getCreditCardAccountObj($dataService) {
     if ($error) {
         logError($error);
     } else {
-        if (sizeof($accountArray) > 0) {
+        if (is_array($accountArray) && sizeof($accountArray) > 0) {
             return current($accountArray);
         }
     }

--- a/InvoiceAndBilling.php
+++ b/InvoiceAndBilling.php
@@ -140,7 +140,7 @@ function getCustomerObj($dataService) {
     if ($error) {
         logError($error);
     } else {
-        if (sizeof($customerArray) > 0) {
+        if (is_array($customerArray) && sizeof($customerArray) > 0) {
             return current($customerArray);
         }
     }
@@ -171,7 +171,7 @@ function getItemObj($dataService) {
     if ($error) {
         logError($error);
     } else {
-        if (sizeof($itemArray) > 0) {
+        if (is_array($itemArray) && sizeof($itemArray) > 0) {
             return current($itemArray);
         }
     }
@@ -224,7 +224,7 @@ function getIncomeAccountObj($dataService) {
     if ($error) {
         logError($error);
     } else {
-        if (sizeof($accountArray) > 0) {
+        if (is_array($accountArray) && sizeof($accountArray) > 0) {
             return current($accountArray);
         }
     }
@@ -256,7 +256,7 @@ function getExpenseAccountObj($dataService) {
     if ($error) {
         logError($error);
     } else {
-        if (sizeof($accountArray) > 0) {
+        if (is_array($accountArray) && sizeof($accountArray) > 0) {
             return current($accountArray);
         }
     }
@@ -288,7 +288,7 @@ function getAssetAccountObj($dataService) {
     if ($error) {
         logError($error);
     } else {
-        if (sizeof($accountArray) > 0) {
+        if (is_array($accountArray) && sizeof($accountArray) > 0) {
             return current($accountArray);
         }
     }

--- a/LandingTheJob.php
+++ b/LandingTheJob.php
@@ -172,7 +172,7 @@ function getItemObj($dataService) {
     if ($error) {
         logError($error);
     } else {
-        if (sizeof($itemArray) > 0) {
+        if (is_array($itemArray) && sizeof($itemArray) > 0) {
             return current($itemArray);
         }
     }
@@ -226,7 +226,7 @@ function getCustomerObj($dataService) {
     if ($error) {
         logError($error);
     } else {
-        if (sizeof($customerArray) > 0) {
+        if (is_array($customerArray) && sizeof($customerArray) > 0) {
             return current($customerArray);
         }
     }
@@ -254,7 +254,7 @@ function getIncomeAccountObj($dataService) {
     if ($error) {
         logError($error);
     } else {
-        if (sizeof($accountArray) > 0) {
+        if (is_array($accountArray) && sizeof($accountArray) > 0) {
             return current($accountArray);
         }
     }
@@ -286,7 +286,7 @@ function getExpenseAccountObj($dataService) {
     if ($error) {
         logError($error);
     } else {
-        if (sizeof($accountArray) > 0) {
+        if (is_array($accountArray) && sizeof($accountArray) > 0) {
             return current($accountArray);
         }
     }
@@ -318,7 +318,7 @@ function getAssetAccountObj($dataService) {
     if ($error) {
         logError($error);
     } else {
-        if (sizeof($accountArray) > 0) {
+        if (is_array($accountArray) && sizeof($accountArray) > 0) {
             return current($accountArray);
         }
     }

--- a/ManagingInventory.php
+++ b/ManagingInventory.php
@@ -170,7 +170,7 @@ function getIncomeAccountObj($dataService) {
   if ($error) {
     logError($error);
   } else {
-    if (sizeof($accountArray) > 0) {
+    if (is_array($accountArray) && sizeof($accountArray) > 0) {
       return current($accountArray);
     }
   }
@@ -200,7 +200,7 @@ function getExpenseAccountObj($dataService) {
   if ($error) {
     logError($error);
   } else {
-    if (sizeof($accountArray) > 0) {
+    if (is_array($accountArray) && sizeof($accountArray) > 0) {
       return current($accountArray);
     }
   }
@@ -230,7 +230,7 @@ function getAssetAccountObj($dataService) {
   if ($error) {
     logError($error);
   } else {
-    if (sizeof($accountArray) > 0) {
+    if (is_array($accountArray) && sizeof($accountArray) > 0) {
       return current($accountArray);
     }
   }
@@ -260,7 +260,7 @@ function getCustomerObj($dataService) {
   if ($error) {
     logError($error);
   } else {
-    if (sizeof($customerArray) > 0) {
+    if (is_array($customerArray) && sizeof($customerArray) > 0) {
       return current($customerArray);
     }
   }

--- a/PayBill.php
+++ b/PayBill.php
@@ -207,7 +207,7 @@ function getExpenseAccountObj($dataService) {
     if ($error) {
         logError($error);
     } else {
-        if (sizeof($accountArray) > 0) {
+        if (is_array($accountArray) && sizeof($accountArray) > 0) {
             return current($accountArray);
         }
     }
@@ -240,7 +240,7 @@ function getBankAccountObj($dataService) {
     if ($error) {
         logError($error);
     } else {
-        if (sizeof($accountArray) > 0) {
+        if (is_array($accountArray) && sizeof($accountArray) > 0) {
             return current($accountArray);
         }
     }
@@ -305,7 +305,7 @@ function getVendorObj($dataService) {
     if ($error) {
         logError($error);
     } else {
-        if (sizeof($vendorArray) > 0) {
+        if (is_array($vendorArray) && sizeof($vendorArray) > 0) {
             return current($vendorArray);
         }
     }

--- a/PayBill.php
+++ b/PayBill.php
@@ -274,7 +274,7 @@ function getCustomerObj($dataService) {
     if ($error) {
         logError($error);
     } else {
-        if (sizeof($customerArray) > 0) {
+        if (is_array($customerArray) && sizeof($customerArray) > 0) {
             return current($customerArray);
         }
     }


### PR DESCRIPTION
Currently if you download the master branch and attempt to run the demo in a PHP 7.2 environment, it'll result in several PHP warnings as the code attempts to call sizeof() on a null variable.  This PR addresses these warnings by first checking the variable with is_array().